### PR TITLE
allow filtering out stdlibs and jlls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,7 +41,8 @@ Possible categories:
 ### Security
 -->
 
-{empty}
+- Added the keyword arguments `ignore_stdlibs` and `ignore_jlls` to not show stdlibs and jll packages respectively.
+  This can significantly declutter the graphs for packages with many such dependencies.
 
 
 [diff-unreleased]: https://github.com/tfiers/PkgGraphs.jl/compare/v0.2...main

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -25,7 +25,7 @@ julia> using PkgGraphs
 
 julia> PkgGraphs.open(:Unitful)
 
-julia>  PkgGraphs.open(:Unitful; ignore_stdlibs=true, ignore_jlls=true) # filter stdlibs and jlls
+julia> PkgGraphs.open(:Unitful; ignore_stdlibs=true, ignore_jlls=true) # filter stdlibs and jlls
 ```
 This will open the browser to [this url][dotlink], which renders the following image:
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,6 +24,8 @@ Small tool to visualize the dependency graph of a Julia package.
 julia> using PkgGraphs
 
 julia> PkgGraphs.open(:Unitful)
+
+julia>  PkgGraphs.open(:Unitful; ignore_stdlibs=true, ignore_jlls=true) # filter stdlibs and jlls
 ```
 This will open the browser to [this url][dotlink], which renders the following image:
 

--- a/src/enduser.jl
+++ b/src/enduser.jl
@@ -8,9 +8,9 @@ The given package must be installed in the currently active project.
 
 See also [`webapps`](@ref) and [`Internals.url`](@ref).
 """
-function open(pkgname, base_url = first(webapps))
-    DefaultApplication.open(url(pkgname, base_url))
-    # ↪ Passing a URL (and not a file) opens the browser on all
+function open(pkgname, base_url = first(webapps); kw...)
+    DefaultApplication.open(url(pkgname, base_url; kw...))
+    #   Passing a URL (and not a file) opens the browser on all
     #   platforms. (Even though that is undocumented behaviour:
     #   https://github.com/tpapp/DefaultApplication.jl/issues/12)
     return nothing

--- a/src/internals/dot.jl
+++ b/src/internals/dot.jl
@@ -28,8 +28,9 @@ digraph {
 deps_as_dot(
     pkgname;
     emptymsg = "($pkgname has no dependencies)",
+    ignore_stdlibs::Bool=false, ignore_jlls::Bool=false,
     kw...
-) = to_dot_str(depgraph(pkgname); emptymsg, kw...)
+) = to_dot_str(depgraph(pkgname; ignore_stdlibs, ignore_jlls); emptymsg, kw...)
 
 
 """

--- a/test/main.jl
+++ b/test/main.jl
@@ -17,6 +17,19 @@ using Test
             depgraph("DinnaeExist")
         )
     end
+
+    @test sort(depgraph("Graphs"; ignore_stdlibs=true, ignore_jlls=true)) == [
+        "ArnoldiMethod" => "StaticArrays"
+        "DataStructures" => "Compat"
+        "DataStructures" => "OrderedCollections"
+                "Graphs" => "ArnoldiMethod"
+                "Graphs" => "Compat"
+                "Graphs" => "DataStructures"
+                "Graphs" => "Inflate"
+                "Graphs" => "SimpleTraits"
+          "SimpleTraits" => "MacroTools"
+          "StaticArrays" => "StaticArraysCore"
+    ]
 end
 
 


### PR DESCRIPTION
Without this, large packages become a bit too messy to understand.

For example Plots, without filtering:

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/1282691/210013979-b3003772-e242-4998-8ace-cab8eef35290.png">

with filtering:

<img width="1611" alt="image" src="https://user-images.githubusercontent.com/1282691/210014010-ff0804c8-ccc6-45ca-9dce-e920e6ba1f50.png">

